### PR TITLE
Sort members by last_edited field

### DIFF
--- a/releases/unreleased/sort-members-by-last-edited.yml
+++ b/releases/unreleased/sort-members-by-last-edited.yml
@@ -1,0 +1,8 @@
+---
+title: Sort members by last edited
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Query to members API was using the wrong keyword to sort
+  the items. Use order keyword instead of sort.

--- a/sortinghat/core/importer/backends/openinfra.py
+++ b/sortinghat/core/importer/backends/openinfra.py
@@ -80,7 +80,7 @@ class OpenInfraIDParser:
     # Resource parameters
     PPER_PAGE = 'per_page'
     PPAGE = 'page'
-    PSORT = 'sort'
+    PSORT = 'order'
     PFILTER = 'filter'
     PTOKEN = 'access_token'
 
@@ -157,7 +157,7 @@ class OpenInfraIDParser:
         """
         payload = {
             self.PPER_PAGE: 100,
-            self.PSORT: '-last_edited',
+            self.PSORT: 'last_edited',
             self.PPAGE: 1,
         }
 
@@ -202,7 +202,7 @@ class OpenInfraIDParser:
             if page >= data['last_page']:
                 break
             page += 1
-            payload['page'] = page
+            payload[self.PPAGE] = page
 
     def _create_access_token(self):
         """Create OpenInfra access token."""
@@ -219,5 +219,5 @@ class OpenInfraIDParser:
         r = requests.post(url=self.OPENINFRA_TOKEN_URL, data=data, params=params)
         if not r.ok:
             raise LoadError(cause="OpenInfra token can't be created.")
-        access_token = r.json()['access_token']
+        access_token = r.json()[self.PTOKEN]
         return access_token

--- a/tests/test_openinfra.py
+++ b/tests/test_openinfra.py
@@ -165,7 +165,7 @@ class TestOpenInfraParser(TestCase):
         requests, bodies = setup_mock_server(public=True)
 
         # Run fetch items
-        payload = {OpenInfraIDParser.PSORT: '-last_edited'}
+        payload = {OpenInfraIDParser.PSORT: 'last_edited'}
         parser = OpenInfraIDParser(OPENINFRA_URL)
         raw_items = parser.fetch_items(OPENINFRA_PUBLIC_MEMBERS_URL, payload=payload)
 
@@ -176,8 +176,8 @@ class TestOpenInfraParser(TestCase):
 
         # Check requests
         expected_qs = [
-            {'sort': ['-last_edited']},
-            {'sort': ['-last_edited'], 'page': ['2']}
+            {'order': ['last_edited']},
+            {'order': ['last_edited'], 'page': ['2']}
         ]
         self.assertEqual(len(requests), 2)
         for i, req in enumerate(requests):
@@ -199,8 +199,8 @@ class TestOpenInfraParser(TestCase):
 
         # Check requests
         expected_qs = [
-            {'page': ['1'], 'per_page': ['100'], 'sort': ['-last_edited']},
-            {'page': ['2'], 'per_page': ['100'], 'sort': ['-last_edited']}
+            {'page': ['1'], 'per_page': ['100'], 'order': ['last_edited']},
+            {'page': ['2'], 'per_page': ['100'], 'order': ['last_edited']}
         ]
         self.assertEqual(len(requests), 2)
         for i, req in enumerate(requests):
@@ -230,7 +230,7 @@ class TestOpenInfraParser(TestCase):
 
         # Check requests
         expected_qs = [
-            {'page': ['1'], 'per_page': ['100'], 'sort': ['-last_edited'], 'access_token': ['test_token']}
+            {'page': ['1'], 'per_page': ['100'], 'order': ['last_edited'], 'access_token': ['test_token']}
         ]
         self.assertEqual(len(requests), 1)
         for i, req in enumerate(requests):
@@ -256,13 +256,13 @@ class TestOpenInfraParser(TestCase):
             {
                 'page': ['1'],
                 'per_page': ['100'],
-                'sort': ['-last_edited'],
+                'order': ['last_edited'],
                 'filter': ['last_edited>946684800']
             },
             {
                 'page': ['2'],
                 'per_page': ['100'],
-                'sort': ['-last_edited'],
+                'order': ['last_edited'],
                 'filter': ['last_edited>946684800']
             }
         ]
@@ -353,12 +353,12 @@ class TestOpenInfraParser(TestCase):
             {
                 'page': ['1'],
                 'per_page': ['100'],
-                'sort': ['-last_edited']
+                'order': ['last_edited']
             },
             {
                 'page': ['2'],
                 'per_page': ['100'],
-                'sort': ['-last_edited']
+                'order': ['last_edited']
             }
         ]
         self.assertEqual(len(requests), 2)
@@ -435,7 +435,7 @@ class TestOpenInfraParser(TestCase):
             {
                 'page': ['1'],
                 'per_page': ['100'],
-                'sort': ['-last_edited'],
+                'order': ['last_edited'],
                 'access_token': ['test_token']
             }
         ]


### PR DESCRIPTION
Query to members API was using the wrong keyword to sort the members. Replace 'sort' with 'order'.