### PR TITLE
Fix API token validation error handling

### DIFF
--- a/releases/unreleased/private-api-token-validation.yml
+++ b/releases/unreleased/private-api-token-validation.yml
@@ -1,0 +1,9 @@
+---
+title: Private API token validation
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: |
+  The previous code incorrectly compared the status code against '400'
+  instead of '401' when validating the private API token. As a result,
+  unauthorized access was not properly handled.

--- a/sortinghat/core/importer/backends/openinfra.py
+++ b/sortinghat/core/importer/backends/openinfra.py
@@ -187,9 +187,10 @@ class OpenInfraIDParser:
 
         page = 1
         while True:
+            logger.info(f"Fetching next members from API {payload}")
             r = requests.get(url, params=payload)
-            if self.private_api and r.status_code == '400' and r.json()['error'] == 'invalid_token':
-                logger.warning(r.json()['description'])
+            if self.private_api and r.status_code == 401 and r.json()['error'] == 'invalid_token':
+                logger.warning(r.json())
                 self.access_token = self._create_access_token()
                 payload[self.PTOKEN] = self.access_token
                 continue

--- a/tests/data/openinfra_token_error.json
+++ b/tests/data/openinfra_token_error.json
@@ -1,0 +1,4 @@
+{
+  "error":"invalid_token",
+  "error_description":"the access token provided is expired, revoked, malformed, or invalid for other reasons."
+}


### PR DESCRIPTION
This PR fixes a bug where the status code comparison in the private API token validation was incorrect. The previous code checked for a status code of '400', but it should have been '401' to properly handle unauthorized access.