### PR TITLE
Include company field when affiliations is empty

### DIFF
--- a/releases/unreleased/company-from-affiliations.yml
+++ b/releases/unreleased/company-from-affiliations.yml
@@ -1,0 +1,8 @@
+---
+title: Company as affiliation
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include the company field in individual enrollments when affiliations
+  are not defined and there is a company specified.

--- a/sortinghat/core/importer/backends/openinfra.py
+++ b/sortinghat/core/importer/backends/openinfra.py
@@ -143,6 +143,12 @@ class OpenInfraIDParser:
                 enr = Enrollment(org, start=start, end=end)
                 individual.enrollments.append(enr)
 
+            if not individual.enrollments:
+                company = member.get('company', None)
+                if company:
+                    enr = Enrollment(company)
+                    individual.enrollments.append(enr)
+
             yield individual
 
     def fetch_members(self, from_date=None):


### PR DESCRIPTION
Include the company field in individual enrollments when affiliations are not defined and there is a company specified.