### PR TITLE
[bug] Importing enrollments from company field fails

### DIFF
--- a/releases/unreleased/importation-fails-adding-affiliations.yml
+++ b/releases/unreleased/importation-fails-adding-affiliations.yml
@@ -1,0 +1,8 @@
+---
+title: Importation fails adding affiliations
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fix a bug related to adding enrollments of members
+  from the company field

--- a/sortinghat/core/importer/backends/openinfra.py
+++ b/sortinghat/core/importer/backends/openinfra.py
@@ -146,7 +146,8 @@ class OpenInfraIDParser:
             if not individual.enrollments:
                 company = member.get('company', None)
                 if company:
-                    enr = Enrollment(company)
+                    org = Organization(name=company)
+                    enr = Enrollment(org)
                     individual.enrollments.append(enr)
 
             yield individual

--- a/tests/data/openinfra_page_1.json
+++ b/tests/data/openinfra_page_1.json
@@ -263,7 +263,7 @@
       "pic":"https:\/\/www.gravatar.com\/avatar\/cd0f6f85db68e8cef64144e2072780dd",
       "membership_type":"None",
       "candidate_profile_id":0,
-      "company":null,
+      "company":"MyCompany",
       "groups":[
         71
       ],

--- a/tests/test_openinfra.py
+++ b/tests/test_openinfra.py
@@ -403,6 +403,7 @@ class TestOpenInfraParser(TestCase):
         self.assertEqual(indiv.identities[1].source, "github")
         self.assertEqual(indiv.identities[1].name, "name surname")
         self.assertEqual(indiv.identities[1].username, "random-gh-user")
+        self.assertEqual(indiv.enrollments[0].organization.name, "MyCompany")
 
         indiv = individuals[1]
         self.assertEqual(indiv.uuid, 136853)


### PR DESCRIPTION
This PR fixes a bug introduced in the previous commit that caused the importation to fail when a member without enrollments had a company name