### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,4 +9,4 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: bitergia/release-tools-check-changelog@master
+      - uses: bitergia/release-tools-check-changelog@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build package using Poetry and store result
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: sh-openinfra-dist
           artifact-path: dist
@@ -74,7 +74,7 @@ jobs:
       contents: write
     steps:
       - name: Create a new release on the repository
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package on PyPI
-        uses: chaoss/grimoirelab-github-actions/publish@master
+        uses: chaoss/grimoirelab-github-actions/publish@main
         with:
           artifact-name: sh-openinfra-dist
           artifact-path: dist


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.